### PR TITLE
Fix cross platform cmake toolchain

### DIFF
--- a/agent_control_pkg/CMakeLists.txt
+++ b/agent_control_pkg/CMakeLists.txt
@@ -1,7 +1,20 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Set vcpkg toolchain file - ADD THIS BEFORE project()
-set(CMAKE_TOOLCHAIN_FILE "C:/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "Vcpkg toolchain file")
+# Optionally use vcpkg toolchain if available
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  if(DEFINED ENV{VCPKG_ROOT})
+    set(_VCPKG_TOOLCHAIN "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+    if(EXISTS "${_VCPKG_TOOLCHAIN}")
+      set(CMAKE_TOOLCHAIN_FILE "${_VCPKG_TOOLCHAIN}" CACHE STRING "Vcpkg toolchain file")
+    endif()
+  elseif(WIN32)
+    # Fallback to a common Windows installation path
+    set(_VCPKG_TOOLCHAIN "C:/vcpkg/scripts/buildsystems/vcpkg.cmake")
+    if(EXISTS "${_VCPKG_TOOLCHAIN}")
+      set(CMAKE_TOOLCHAIN_FILE "${_VCPKG_TOOLCHAIN}" CACHE STRING "Vcpkg toolchain file")
+    endif()
+  endif()
+endif()
 
 # Enable compile commands export
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")


### PR DESCRIPTION
## Summary
- make use of the vcpkg toolchain optional in CMakeLists

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "GTest"*)

------
https://chatgpt.com/codex/tasks/task_e_6840245cc52c8323bf3b2a827096aa73