### PR TITLE
Fix comment in pid_controller header

### DIFF
--- a/agent_control_pkg/include/agent_control_pkg/pid_controller.hpp
+++ b/agent_control_pkg/include/agent_control_pkg/pid_controller.hpp
@@ -55,7 +55,7 @@ private:
     // Internal state
     double previous_error_;
     double integral_;
-    bool first_calculation_; // Should be bool
+    bool first_calculation_; // true on first call
 
     double previous_measurement_;
 


### PR DESCRIPTION
## Summary
- clarify `first_calculation_` comment in `pid_controller.hpp`

## Testing
- `cmake ..` *(fails: Could not find GTestConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_684207a0f1788323a8c42cfa48efb808