### PR TITLE
Add runtime flag for FLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The `agent_control_pkg` is set up for a local build.
     ```bash
     Debug\pid_standalone_tester.exe
     ```
+    Use the `--use-fls` flag to enable the fuzzy logic system at runtime.
 3.  The simulation will run, and `multi_drone_sim_data.csv` and `pid_performance_metrics.txt` will be created in the same directory where you ran the executable.
 
 ## Project Structure

--- a/agent_control_pkg/src/agent_control_main.cpp
+++ b/agent_control_pkg/src/agent_control_main.cpp
@@ -129,7 +129,17 @@ void setup_fls_instance(agent_control_pkg::GT2FuzzyLogicSystem& fls) {
 // *** END Added Helper Function ***
 
 
-int main() {
+int main(int argc, char** argv) {
+    bool use_fls_flag = false;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--use-fls" || arg == "--enable-fls") {
+            use_fls_flag = true;
+        } else if (arg == "--help" || arg == "-h") {
+            std::cout << "Usage: " << argv[0] << " [--use-fls]" << std::endl;
+            return 0;
+        }
+    }
     // >>> ZIEGLER-NICHOLS TUNING SECTION - SETTINGS FOR Ku/Pu FINDING <<<
     const bool ZN_TUNING_ACTIVE = false;  // SET TO false FOR NORMAL RUN WITH Z-N GAINS
                                          // WHEN true, FLS WILL BE OFF, AND PID WILL BE P-ONLY
@@ -140,7 +150,7 @@ int main() {
     // >>> END ZIEGLER-NICHOLS TUNING SECTION <<<
 
     // Flag to control FLS usage
-    const bool USE_FLS = !ZN_TUNING_ACTIVE && false; // Set to false for PID-only run with Z-N gains
+    const bool USE_FLS = !ZN_TUNING_ACTIVE && use_fls_flag;
 
     const int NUM_DRONES = 3;
     std::vector<FakeDrone> drones(NUM_DRONES);


### PR DESCRIPTION
## Summary
- parse `--use-fls` flag in `agent_control_main.cpp`
- wire flag to enable/disable fuzzy logic
- document the new option in `README`

## Testing
- `cmake ..` *(fails: Could not find GTestConfig.cmake)*
- `make -j$(nproc)` *(fails: No targets specified and no makefile found)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684212bed3888323a399da4d332db511