### PR TITLE
Add config flags for wind and FLS

### DIFF
--- a/agent_control_pkg/config/simulation_params.yaml
+++ b/agent_control_pkg/config/simulation_params.yaml
@@ -42,9 +42,13 @@ wind:
         - {start: 65.0, end: 70.0, force: ["sin", 0.0]} # Special case for sine wave
         - {start: 70.0, end: 72.0, force: [0.0, 4.0]}
         - {start: 72.0, end: 75.0, force: [0.0, -2.0]}
-    - phase: 4
-      time_windows:
-        - {start: 95.0, end: 105.0, force: [2.5, -2.5]}
+  - phase: 4
+    time_windows:
+      - {start: 95.0, end: 105.0, force: [2.5, -2.5]}
+
+# Controller Settings
+controller:
+  fls_enabled: false
 
 # Output Settings
 output:

--- a/agent_control_pkg/include/agent_control_pkg/config_reader.hpp
+++ b/agent_control_pkg/include/agent_control_pkg/config_reader.hpp
@@ -48,6 +48,9 @@ struct SimulationConfig {
     bool wind_enabled;
     std::vector<WindPhase> wind_phases;
 
+    // Controller Settings
+    bool fls_enabled;
+
     // Output Settings
     bool csv_enabled;
     std::string csv_prefix;

--- a/agent_control_pkg/src/config_reader.cpp
+++ b/agent_control_pkg/src/config_reader.cpp
@@ -57,7 +57,15 @@ void ConfigReader::loadSimulationParams(SimulationConfig& config, const YAML::No
         config.phases.push_back(phase_config);
     }
 
-    // Load wind settings
+    // Load wind and controller settings
+    config.wind_enabled = sim_yaml["wind"]["enabled"].as<bool>();
+    if (sim_yaml["controller"] && sim_yaml["controller"].IsMap()) {
+        config.fls_enabled = sim_yaml["controller"]["fls_enabled"].as<bool>();
+    } else {
+        config.fls_enabled = false;
+    }
+
+    // Load detailed wind configuration
     loadWindConfig(config, sim_yaml["wind"]);
 
     // Load output settings
@@ -68,7 +76,6 @@ void ConfigReader::loadSimulationParams(SimulationConfig& config, const YAML::No
 }
 
 void ConfigReader::loadWindConfig(SimulationConfig& config, const YAML::Node& wind_node) {
-    config.wind_enabled = wind_node["enabled"].as<bool>();
     config.wind_phases.clear();
     
     if (!config.wind_enabled) return;


### PR DESCRIPTION
## Summary
- add controller.fls_enabled to the sample simulation params YAML
- extend SimulationConfig with `fls_enabled`
- parse wind.enabled and controller.fls_enabled in `ConfigReader`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6842ccbdc88c8323816c05bdcf1a3fd3