### PR TITLE
Add fuzzy logic config fields and loader

### DIFF
--- a/agent_control_pkg/CMakeLists.txt
+++ b/agent_control_pkg/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 # --- Config Reader Library ---
 add_library(config_reader_lib
     src/config_reader.cpp
+    src/fuzzy_params_loader.cpp
 )
 target_include_directories(config_reader_lib PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/agent_control_pkg/config/simulation_params.yaml
+++ b/agent_control_pkg/config/simulation_params.yaml
@@ -52,4 +52,9 @@ output:
   csv_prefix: "multi_drone_pid_test"
   console_output:
     enabled: true
-    update_interval: 5.0  # seconds 
+    update_interval: 5.0  # seconds
+
+# Fuzzy Logic Settings
+fuzzy_logic:
+  enabled: true
+  params_file: "fuzzy_params.yaml"

--- a/agent_control_pkg/include/agent_control_pkg/config_reader.hpp
+++ b/agent_control_pkg/include/agent_control_pkg/config_reader.hpp
@@ -53,6 +53,10 @@ struct SimulationConfig {
     std::string csv_prefix;
     bool console_output_enabled;
     double console_update_interval;
+
+    // Fuzzy Logic Settings
+    bool fls_enabled{false};
+    std::string fuzzy_params_file{"fuzzy_params.yaml"};
 };
 
 class ConfigReader {

--- a/agent_control_pkg/include/agent_control_pkg/fuzzy_params_loader.hpp
+++ b/agent_control_pkg/include/agent_control_pkg/fuzzy_params_loader.hpp
@@ -1,0 +1,24 @@
+#ifndef AGENT_CONTROL_PKG__FUZZY_PARAMS_LOADER_HPP_
+#define AGENT_CONTROL_PKG__FUZZY_PARAMS_LOADER_HPP_
+
+#include <array>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace agent_control_pkg {
+
+struct FuzzySetFOU {
+    double l1, l2, l3, u1, u2, u3;
+};
+
+struct FuzzyParams {
+    std::map<std::string, std::map<std::string, FuzzySetFOU>> sets;
+    std::vector<std::array<std::string,4>> rules;
+};
+
+bool loadFuzzyParams(const std::string& file, FuzzyParams& fp);
+
+} // namespace agent_control_pkg
+
+#endif // AGENT_CONTROL_PKG__FUZZY_PARAMS_LOADER_HPP_

--- a/agent_control_pkg/src/config_reader.cpp
+++ b/agent_control_pkg/src/config_reader.cpp
@@ -65,6 +65,18 @@ void ConfigReader::loadSimulationParams(SimulationConfig& config, const YAML::No
     config.csv_prefix = sim_yaml["output"]["csv_prefix"].as<std::string>();
     config.console_output_enabled = sim_yaml["output"]["console_output"]["enabled"].as<bool>();
     config.console_update_interval = sim_yaml["output"]["console_output"]["update_interval"].as<double>();
+
+    // Load fuzzy logic settings with defaults
+    config.fls_enabled = false;
+    config.fuzzy_params_file = "fuzzy_params.yaml";
+    if (sim_yaml["fuzzy_logic"]) {
+        if (sim_yaml["fuzzy_logic"]["enabled"]) {
+            config.fls_enabled = sim_yaml["fuzzy_logic"]["enabled"].as<bool>();
+        }
+        if (sim_yaml["fuzzy_logic"]["params_file"]) {
+            config.fuzzy_params_file = sim_yaml["fuzzy_logic"]["params_file"].as<std::string>();
+        }
+    }
 }
 
 void ConfigReader::loadWindConfig(SimulationConfig& config, const YAML::Node& wind_node) {

--- a/agent_control_pkg/src/fuzzy_params_loader.cpp
+++ b/agent_control_pkg/src/fuzzy_params_loader.cpp
@@ -1,0 +1,94 @@
+#include "agent_control_pkg/fuzzy_params_loader.hpp"
+#include <fstream>
+#include <sstream>
+#include <cctype>
+
+namespace agent_control_pkg {
+
+static std::string trim(const std::string& s) {
+    size_t start = s.find_first_not_of(" \t\r\n");
+    size_t end = s.find_last_not_of(" \t\r\n");
+    if(start==std::string::npos) return "";
+    return s.substr(start, end-start+1);
+}
+
+static std::vector<double> parseNumberList(const std::string& in) {
+    std::vector<double> values;
+    std::stringstream ss(in);
+    std::string tok;
+    while(std::getline(ss, tok, ',')) {
+        tok = trim(tok);
+        if(!tok.empty()) values.push_back(std::stod(tok));
+    }
+    return values;
+}
+
+static std::vector<std::string> parseStringList(const std::string& in) {
+    std::vector<std::string> values;
+    std::stringstream ss(in);
+    std::string tok;
+    while(std::getline(ss, tok, ',')) {
+        values.push_back(trim(tok));
+    }
+    return values;
+}
+
+static std::string findConfigFile(const std::string& filename) {
+    std::vector<std::string> candidates = {
+        "../config/" + filename,
+        "../../config/" + filename,
+        "config/" + filename,
+    };
+    for(const auto& p : candidates) {
+        std::ifstream f(p);
+        if(f.good()) return p;
+    }
+    return filename;
+}
+
+bool loadFuzzyParams(const std::string& file, FuzzyParams& fp) {
+    std::ifstream in(findConfigFile(file));
+    if(!in.is_open()) {
+        return false;
+    }
+    std::string line;
+    std::string section;
+    std::string current_var;
+    while(std::getline(in,line)) {
+        line = trim(line);
+        if(line.empty() || line[0]=='#') continue;
+        if(line == "membership_functions:") { section = "mf"; continue; }
+        if(line == "rules:") { section = "rules"; continue; }
+        if(section == "mf") {
+            if(line.back()==':') {
+                current_var = trim(line.substr(0,line.size()-1));
+                continue;
+            }
+            auto pos = line.find(':');
+            if(pos==std::string::npos) continue;
+            std::string setname = trim(line.substr(0,pos));
+            std::string rest = line.substr(pos+1);
+            auto lb = rest.find('[');
+            auto rb = rest.find(']');
+            if(lb==std::string::npos || rb==std::string::npos) continue;
+            std::string nums = rest.substr(lb+1, rb-lb-1);
+            auto values = parseNumberList(nums);
+            if(values.size()==6) {
+                fp.sets[current_var][setname] = {values[0],values[1],values[2],values[3],values[4],values[5]};
+            }
+        } else if(section == "rules") {
+            if(line[0]=='-') {
+                auto lb=line.find('[');
+                auto rb=line.find(']');
+                if(lb==std::string::npos || rb==std::string::npos) continue;
+                auto tokens = parseStringList(line.substr(lb+1, rb-lb-1));
+                if(tokens.size()==4) {
+                    fp.rules.push_back({tokens[0],tokens[1],tokens[2],tokens[3]});
+                }
+            }
+        }
+    }
+    return true;
+}
+
+} // namespace agent_control_pkg


### PR DESCRIPTION
## Summary
- support FLS options in `SimulationConfig`
- parse new parameters from YAML
- add helper for loading fuzzy parameters
- update sample configuration and build files

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6842ccdd5dc88323a26c3f7db492bd64