### PR TITLE
Update multi_drone_pid_tester link options

### DIFF
--- a/agent_control_pkg/CMakeLists.txt
+++ b/agent_control_pkg/CMakeLists.txt
@@ -177,6 +177,7 @@ target_include_directories(multi_drone_pid_tester PRIVATE
 target_link_libraries(multi_drone_pid_tester PRIVATE
     pid_logic_lib  # Link against your PID library
     config_reader_lib  # Link against config reader library
+    fuzzy_logic_lib
 )
 
 # Copy compile_commands.json to source directory


### PR DESCRIPTION
## Summary
- link `multi_drone_pid_tester` against `fuzzy_logic_lib`

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6842ccee2aa08323b9142a7279b11bfd